### PR TITLE
Prevent race condition (updated for style rules)

### DIFF
--- a/src/Resumable.php
+++ b/src/Resumable.php
@@ -268,13 +268,29 @@ class Resumable
         return $filename . '.' . str_pad($chunkNumber, 4, 0, STR_PAD_LEFT);
     }
 
+    public function getExclusiveFileHandle($name)
+    {
+        // if the file exists, fopen() will raise a warning
+        $previous_error_level = error_reporting();
+        error_reporting(E_ERROR);
+        $handle = fopen($name, 'x');
+        error_reporting($previous_error_level);
+        return $handle;
+    }
+
     public function createFileFromChunks($chunkFiles, $destFile)
     {
         $this->log('Beginning of create files from chunks');
 
         natsort($chunkFiles);
 
-        $destFile = new File($destFile, true);
+        $handle = $this->getExclusiveFileHandle9$destFile);
+        if (!$handle) {
+            return false;
+        }
+
+        $destFile = new File($destFile);
+        $destFile->handle = $handle;
         foreach ($chunkFiles as $chunkFile) {
             $file = new File($chunkFile);
             $destFile->append($file->read());


### PR DESCRIPTION
When I test this on my machine, the last two processes to read a chunk will occasionally both attempt to write the combined file.

Cakephp *can* use locking to ensure no more than one process writes to a file *at a time*, however it does not guarantee that only one process writes to a file at all. For this, we need to open the file with the `O_EXCL` flag (`x` in PHP).

This pull request ensures only one process will write to `destFile`.